### PR TITLE
fix #4

### DIFF
--- a/lib/ColorThief/Image/ImageLoader.php
+++ b/lib/ColorThief/Image/ImageLoader.php
@@ -80,6 +80,7 @@ class ImageLoader
     public function getAdapter($adapterType)
     {
         $classname = '\\ColorThief\\Image\\Adapter\\' . $adapterType . 'ImageAdapter';
+        require_once __DIR__ . '/Adapter/' . $adapterType . 'ImageAdapter.php';
 
         return new $classname();
     }


### PR DESCRIPTION
- Fix `PHP Fatal error:  Uncaught Error: Class '\ColorThief\Image\Adapter\GDImageAdapter' not found` error. We don't use the Composer class autoload feature, and so need to include all the required files manually.