### PR TITLE
Fix image loading to get a proper resource object

### DIFF
--- a/includes/color-detect.php
+++ b/includes/color-detect.php
@@ -8,12 +8,14 @@ include_once plugin_dir_path(__FILE__) . "../lib/ColorThief/ColorThief.php";
 include_once plugin_dir_path(__FILE__) . "../lib/ColorThief/Image/ImageLoader.php";
 include_once plugin_dir_path(__FILE__) . "../lib/ColorThief/Image/Adapter/IImageAdapter.php";    
 include_once plugin_dir_path(__FILE__) . "../lib/ColorThief/Image/Adapter/ImageAdapter.php";    
+include_once plugin_dir_path(__FILE__) . "../lib/ColorThief/Image/Adapter/GDImageAdapter.php";
 include_once plugin_dir_path(__FILE__) . "../lib/ColorThief/Image/Adapter/ImagickImageAdapter.php";        
 include_once plugin_dir_path(__FILE__) . "../lib/ColorThief/VBox.php";
 include_once plugin_dir_path(__FILE__) . "../lib/ColorThief/PQueue.php";    
 include_once plugin_dir_path(__FILE__) . "../lib/ColorThief/CMap.php";        
 use ColorThief\ColorThief;
 use ColorThief\Image\ImageLoader;
+use ColorThief\Image\Adapter\GDImageAdapter;
 
 
 /**
@@ -32,8 +34,9 @@ function fh_seo_attachment_set_colors($attachment_id){
         return false;
     }
 
-    $loader = new ImageLoader();
-    $image = $loader->load($path);
+    $loader = new GDImageAdapter();
+    $loader->loadFile($path);
+    $image = $loader->getResource();
 
     $is_transparent = fh_seo_image_has_transparency($image);
     


### PR DESCRIPTION
This handles the issue in #10 and possibly #12 (although my local version now fails setting a focal point, I suspect this is an issue with Azure accessing my media).

The issue was caused by the `ColorThief/ImageLoader` class returning an `ImageAdapter` object whereas the `fh_seo_image_has_transparency` expected a `GDImage` resource. `ImageAdapter` also switches between Imagick/Gmagick/GDImage if they are available, so this change directly accesses ColorThief's `GDImageAdapter` to load the image (as the class helpfully handles files of different formats).