### PR TITLE
Fixed warnings with getimagesize on upload

### DIFF
--- a/includes/rename-image.php
+++ b/includes/rename-image.php
@@ -144,15 +144,20 @@ function fh_seo_attachment_rename( $post_id, $filename ) {
 
 	// Register filter to update metadata
 	$new_data = wp_generate_attachment_metadata( $post_id, $new_path );
+
+	// phpcs:disable WordPress.PHP.DevelopmentFunctions.prevent_path_disclosure_error_reporting, WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting
+	$current_error_reporting = error_reporting();
+	error_reporting( $current_error_reporting & ~E_WARNING );
 	add_filter(
 		'wp_update_attachment_metadata',
-		function( $data, $post_id ) use ( $new_data ) {
+		function( $data, $post_id ) use ( $new_data, $current_error_reporting ) {
+			error_reporting( $current_error_reporting );
 			return $new_data;
 		},
 		10,
 		2
 	);
-
+	// phpcs:enable
 }
 
 /**


### PR DESCRIPTION
Fixed issue #21

We replace the image file name with SEO friendly one on upload and it creates some warnings on metadata generation.
There is no hook to update the `$file` value in `media_handle_upload`, so used suppress warning method to bypass the warnings.